### PR TITLE
Add handling for missing SAML attribute data

### DIFF
--- a/Security/Firewall/SamlListener.php
+++ b/Security/Firewall/SamlListener.php
@@ -43,9 +43,8 @@ class SamlListener extends AbstractAuthenticationListener
 
         if (isset($this->options['username_attribute'])) {
             if (array_key_exists($this->options['username_attribute'],$attributes)===false){
-                $this->logger->error(sprintf("Expected Attribute: %s Is not found in SAML data"));
                 $this->logger->error(sprintf("Found Attributes: %s",print_r($attributes,true)));
-                throw new \Exception(sprintf("Expected Attribute: %s Is not found in SAML data"));
+                throw new \Exception(sprintf("Expected Attribute: %s Is not found in SAML data",$this->options['username_attribute']));
 
             }
             $username = $attributes[$this->options['username_attribute']][0];

--- a/Security/Firewall/SamlListener.php
+++ b/Security/Firewall/SamlListener.php
@@ -42,6 +42,12 @@ class SamlListener extends AbstractAuthenticationListener
         $token->setAttributes($attributes);
 
         if (isset($this->options['username_attribute'])) {
+            if (array_key_exists($this->options['username_attribute'],$attributes)===false){
+                $this->logger->error(sprintf("Expected Attribute: %s Is not found in SAML data"));
+                $this->logger->error(sprintf("Found Attributes: %s",print_r($attributes,true)));
+                throw new \Exception(sprintf("Expected Attribute: %s Is not found in SAML data"));
+
+            }
             $username = $attributes[$this->options['username_attribute']][0];
         } else {
             $username = $this->oneLoginAuth->getNameId();


### PR DESCRIPTION
Our client had misconfigured their IDP, and it was very challenging to debug that the attribute was incorrect.

If it's set, it seems to be that it should be required.