### PR TITLE
Add support for "wantAssertionsEncrypted" security option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -99,6 +99,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('logoutResponseSigned')->end()
                         ->booleanNode('wantMessagesSigned')->end()
                         ->booleanNode('wantAssertionsSigned')->end()
+                        ->booleanNode('wantAssertionsEncrypted')->end()
                         ->booleanNode('wantNameId')->end()
                         ->booleanNode('wantNameIdEncrypted')->end()
                         ->booleanNode('requestedAuthnContext')->end()


### PR DESCRIPTION
Add config point for php-saml parameters. It enables including an encryption keyDescriptor to metadata without using "wantNameIdEncrypted" security option.