### PR TITLE
Allow using the attribute's friendly name when retrieving attributes

### DIFF
--- a/DependencyInjection/Security/Factory/SamlFactory.php
+++ b/DependencyInjection/Security/Factory/SamlFactory.php
@@ -13,6 +13,7 @@ class SamlFactory extends AbstractFactory
     public function __construct()
     {
         $this->addOption('username_attribute');
+        $this->addOption('use_attribute_friendly_name', false);
         $this->addOption('check_path', '/saml/acs');
         $this->addOption('user_factory');
         $this->addOption('token_factory');

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ security:
                 # Match SAML attribute 'uid' with username.
                 # Uses getNameId() method by default.
                 username_attribute: uid
+                # Use the attribute's friendlyName instead of the name 
+                use_attribute_friendly_name: true
                 check_path: /saml/acs
                 login_path: /saml/login
             logout:

--- a/Security/Firewall/SamlListener.php
+++ b/Security/Firewall/SamlListener.php
@@ -41,7 +41,12 @@ class SamlListener extends AbstractAuthenticationListener
             throw new AuthenticationException($this->oneLoginAuth->getLastErrorReason());
         }
 
-        $attributes = $this->oneLoginAuth->getAttributes();
+        $attributes = [];
+        if (isset($this->options['use_attribute_friendly_name']) && $this->options['use_attribute_friendly_name']) {
+            $attributes = $this->oneLoginAuth->getAttributesWithFriendlyName();
+        } else {
+            $attributes = $this->oneLoginAuth->getAttributes();
+        }
         $attributes['sessionIndex'] = $this->oneLoginAuth->getSessionIndex();
         $token = new SamlToken();
         $token->setAttributes($attributes);


### PR DESCRIPTION
Some IDP provide the attribute Name with an OID (ex: urn:oid:2.5.4.42 instead of givenName), and a FriendlyName (with the value givenName). 
The php-saml lib has a method to retrieve attributes with FriendlyName instead of the name, thanks to https://github.com/onelogin/php-saml/pull/270

This PR allow to use the FriendlyName instead of name, when needed.