### PR TITLE
Allow the use of a custom EntityManager

### DIFF
--- a/DependencyInjection/Compiler/SecurityCompilerPass.php
+++ b/DependencyInjection/Compiler/SecurityCompilerPass.php
@@ -2,18 +2,36 @@
 
 namespace Hslavich\OneloginSamlBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Hslavich\OneloginSamlBundle\DependencyInjection\Configuration;
 
 class SecurityCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('doctrine.orm.default_entity_manager')) {
+        $configs = $container->getExtensionConfig('hslavich_onelogin_saml');
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+        $emDefinition='doctrine.orm.default_entity_manager';
+        if(!empty($config['security']) && isset($config['security']['entityManagerName'])){
+            $emDefinition='doctrine.orm.'.$config['security']['entityManagerName'].'_entity_manager';
+        }
+       
+        if ($container->hasDefinition($emDefinition)) {
             foreach ($container->findTaggedServiceIds('hslavich.saml_provider') as $id => $tags) {
-                $container->getDefinition($id)->addMethodCall('setEntityManager', array(new Reference('doctrine.orm.default_entity_manager')));
+                $container->getDefinition($id)->addMethodCall('setEntityManager', array(new Reference($emDefinition)));
             }
         }
+        throw new \Exception($emDefinition);
+    }
+
+    private function processConfiguration(ConfigurationInterface $configuration, array $configs)
+    {
+        $processor = new Processor();
+        return $processor->processConfiguration($configuration, $configs);
     }
 }

--- a/DependencyInjection/Compiler/SecurityCompilerPass.php
+++ b/DependencyInjection/Compiler/SecurityCompilerPass.php
@@ -26,7 +26,6 @@ class SecurityCompilerPass implements CompilerPassInterface
                 $container->getDefinition($id)->addMethodCall('setEntityManager', array(new Reference($emDefinition)));
             }
         }
-        throw new \Exception($emDefinition);
     }
 
     private function processConfiguration(ConfigurationInterface $configuration, array $configs)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -108,6 +108,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('lowercaseUrlencoding')->end()
                         ->scalarNode('signatureAlgorithm')->end()
                         ->scalarNode('digestAlgorithm')->end()
+                        ->scalarNode('entityManagerName')->end()
                     ->end()
                 ->end()
                 ->arrayNode('contactPerson')


### PR DESCRIPTION
For a personal project, I forked your project to add the possibility to use a custom EntityManager for authentication. So why not sharing my work. 

How I did that : 
  - I have added a new optional configuration parameter called "entityManagerName"  in the section "security" of your bundle configuration in config.php 
  - The compiler class was modified to load the "entityManagerName" parameter and to inject the corresponding EntityManager reference in the bundle definition
