### PR TITLE
baseurl in configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('baseurl')->end()
                 ->booleanNode('strict')->end()
                 ->booleanNode('debug')->end()
                 ->arrayNode('idp')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,8 +19,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('hslavich_saml_sp');
+        if (PHP_VERSION_ID < 70100) {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('hslavich_saml_sp');
+        } else {
+            $treeBuilder = new TreeBuilder('hslavich_saml_sp');
+            $rootNode = $treeBuilder->getRootNode();
+        }
 
         $rootNode
             ->children()

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ hslavich_onelogin_saml:
             url: 'http://myapp.com/app_dev.php/saml/logout'
             binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
     # Optional settings
+    baseurl: 'http://myapp.com'
     strict: true
     debug: true    
     security:

--- a/Tests/DependencyInjection/Fixtures/full.yaml
+++ b/Tests/DependencyInjection/Fixtures/full.yaml
@@ -25,6 +25,7 @@ hslavich_onelogin_saml:
             url: 'http://myapp.com/app_dev.php/saml/logout'
             binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
     strict: true
+    baseurl: 'http://myapp.com/app_dev.php/saml/'
     debug: false
     security:
         nameIdEncrypted:       false

--- a/Tests/DependencyInjection/HslavichOneloginSamlExtensionTest.php
+++ b/Tests/DependencyInjection/HslavichOneloginSamlExtensionTest.php
@@ -66,6 +66,7 @@ class HslavichOneloginSamlExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($settings['strict']);
         $this->assertFalse($settings['debug']);
+        $this->assertEquals('http://myapp.com/app_dev.php/saml/', $settings['baseurl']);
     }
 
     public function testLoadOrganizationSettings()


### PR DESCRIPTION
Enable to set `baseurl` config variable. It's useful when you are behind reverse proxy.

It resolves #75 too.