### PR TITLE
remove deprecations from Symfony 4.2

### DIFF
--- a/Controller/SamlController.php
+++ b/Controller/SamlController.php
@@ -2,12 +2,12 @@
 
 namespace Hslavich\OneloginSamlBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\HttpFoundation\Request;
 
-class SamlController extends Controller
+class SamlController extends AbstractController
 {
     public function loginAction(Request $request)
     {

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,15 +1,15 @@
 saml_metadata:
     path:     /saml/metadata
-    defaults: { _controller: HslavichOneloginSamlBundle:Saml:metadata }
+    defaults: { _controller: Hslavich\OneloginSamlBundle\Controller\SamlController::metadataAction }
 
 saml_acs:
     path:     /saml/acs
-    defaults: { _controller: HslavichOneloginSamlBundle:Saml:assertionConsumerService }
+    defaults: { _controller: Hslavich\OneloginSamlBundle\Controller\SamlController::assertionConsumerServiceAction }
 
 saml_login:
     path:     /saml/login
-    defaults: { _controller: HslavichOneloginSamlBundle:Saml:login }
+    defaults: { _controller: Hslavich\OneloginSamlBundle\Controller\SamlController::loginAction }
 
 saml_logout:
     path:     /saml/logout
-    defaults: { _controller: HslavichOneloginSamlBundle:Saml:singleLogoutService }
+    defaults: { _controller: Hslavich\OneloginSamlBundle\Controller\SamlController::singleLogoutServiceAction }


### PR DESCRIPTION
- In Symfony 4.2 the `Symfony\Bundle\FrameworkBundle\Controller\Controller` is deprecated, `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` should be used instead
- In `Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader.php`, which allows to load routes into our application, the route described like that `AuthorNameBundle:ControllerName:methodWithoutAction` is deprecated. The new way is `Author\NameBundle\Controller\ControllerName::methodAction`