### PR TITLE
Update .travis.yml for check PHP7.2 and Symfony4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*
+    - php: 7.2
+      env: SYMFONY_VERSION=4.2.*
 
 sudo: false
 


### PR DESCRIPTION
For check OneloginSamlBundle is valide with PHP7.2 and Symfony4.2