### PR TITLE
Change private variables to protected for easier extension

### DIFF
--- a/Security/Authentication/Provider/SamlProvider.php
+++ b/Security/Authentication/Provider/SamlProvider.php
@@ -15,11 +15,11 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class SamlProvider implements AuthenticationProviderInterface
 {
-    private $userProvider;
-    private $userFactory;
-    private $tokenFactory;
-    private $entityManager;
-    private $options;
+    protected $userProvider;
+    protected $userFactory;
+    protected $tokenFactory;
+    protected $entityManager;
+    protected $options;
 
     public function __construct(UserProviderInterface $userProvider, array $options = array())
     {


### PR DESCRIPTION
I needed to extend retrieveUser but it was harder than it had to bc these object variables were private and not protected.