### PR TITLE
Redirect user to original URL after authentication

### DIFF
--- a/Controller/SamlController.php
+++ b/Controller/SamlController.php
@@ -27,7 +27,7 @@ class SamlController extends AbstractController
             throw new \RuntimeException($error->getMessage());
         }
 
-        $this->get('onelogin_auth')->login();
+        $this->get('onelogin_auth')->login($session->get('_security.main.target_path'));
     }
 
     public function metadataAction()

--- a/DependencyInjection/Security/Factory/SamlFactory.php
+++ b/DependencyInjection/Security/Factory/SamlFactory.php
@@ -19,6 +19,7 @@ class SamlFactory extends AbstractFactory
         $this->addOption('token_factory');
         $this->addOption('persist_user', false);
 
+        $this->options['success_handler'] = 'hslavich_onelogin_saml.saml_authentication_success_handler';
         $this->defaultFailureHandlerOptions['login_path'] = '/saml/login';
     }
 

--- a/DependencyInjection/Security/Factory/SamlFactory.php
+++ b/DependencyInjection/Security/Factory/SamlFactory.php
@@ -18,8 +18,10 @@ class SamlFactory extends AbstractFactory
         $this->addOption('user_factory');
         $this->addOption('token_factory');
         $this->addOption('persist_user', false);
-
-        $this->options['success_handler'] = 'hslavich_onelogin_saml.saml_authentication_success_handler';
+        
+        if (!isset($this->options['success_handler'])) {
+            $this->options['success_handler'] = 'hslavich_onelogin_saml.saml_authentication_success_handler';
+        }
         $this->defaultFailureHandlerOptions['login_path'] = '/saml/login';
     }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -18,7 +18,7 @@ services:
 
     hslavich_onelogin_saml.saml_authentication_success_handler:
         class: Hslavich\OneloginSamlBundle\Security\Authentication\SamlAuthenticationSuccessHandler
-        arguments: ["@security.http_utils", []]
+        parent: security.authentication.success_handler
 
     hslavich_onelogin_saml.saml_listener:
         class: Hslavich\OneloginSamlBundle\Security\Firewall\SamlListener

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -16,6 +16,10 @@ services:
     hslavich_onelogin_saml.saml_token_factory:
         class: Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlTokenFactory
 
+    hslavich_onelogin_saml.saml_authentication_success_handler:
+        class: Hslavich\OneloginSamlBundle\Security\Authentication\SamlAuthenticationSuccessHandler
+        arguments: ["@security.http_utils", []]
+
     hslavich_onelogin_saml.saml_listener:
         class: Hslavich\OneloginSamlBundle\Security\Firewall\SamlListener
         parent: security.authentication.listener.abstract

--- a/Security/Authentication/SamlAuthenticationSuccessHandler.php
+++ b/Security/Authentication/SamlAuthenticationSuccessHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Hslavich\OneloginSamlBundle\Security\Authentication;
+
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+use Symfony\Component\HttpFoundation\Request;
+
+class SamlAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
+{
+    protected function determineTargetUrl(Request $request)
+    {
+        if ($this->options['always_use_default_target_path']) {
+            return $this->options['default_target_path'];
+        }
+
+        $relayState = $request->get('RelayState');
+        if (null !== $relayState && $relayState !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
+            return $relayState;
+        }
+
+        return parent::determineTargetUrl($request);
+    }
+}

--- a/Tests/Authentication/Provider/SamlProviderTest.php
+++ b/Tests/Authentication/Provider/SamlProviderTest.php
@@ -26,7 +26,11 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Hslavich\\OneloginSamlBundle\\Security\\Authentication\\Token\\SamlToken', $token);
         $this->assertEquals(array('foo' => 'bar'), $token->getAttributes());
-        $this->assertEquals(array(), $token->getRoles());
+        if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID >= 40300) {
+            $this->assertEquals(array(), $token->getRoleNames());
+        } else {
+            $this->assertEquals(array(), $token->getRoles());
+        }
         $this->assertTrue($token->isAuthenticated());
         $this->assertSame($user, $token->getUser());
     }
@@ -53,7 +57,11 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Hslavich\\OneloginSamlBundle\\Security\\Authentication\\Token\\SamlToken', $token);
         $this->assertEquals(array('foo' => 'bar'), $token->getAttributes());
-        $this->assertEquals(array(), $token->getRoles());
+        if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID >= 40300) {
+            $this->assertEquals(array(), $token->getRoleNames());
+        } else {
+            $this->assertEquals(array(), $token->getRoles());
+        }
         $this->assertTrue($token->isAuthenticated());
         $this->assertSame($user, $token->getUser());
     }

--- a/Tests/Authentication/SamlAuthenticationSuccessHandlerTest.php
+++ b/Tests/Authentication/SamlAuthenticationSuccessHandlerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Hslavich\OneloginSamlBundle\Tests\Authentication;
+
+use Hslavich\OneloginSamlBundle\Security\Authentication\SamlAuthenticationSuccessHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\HttpUtils;
+
+class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    private $handler;
+
+    public function testWithAlwaysUseDefaultTargetPath()
+    {
+        $httpUtils = new HttpUtils($this->getUrlGenerator());
+        $handler = new SamlAuthenticationSuccessHandler($httpUtils, array('always_use_default_target_path' => true));
+        $defaultTargetPath = $httpUtils->generateUri($this->getRequest('/sso/login'), $this->getOption($handler, 'default_target_path', '/'));
+        $response = $handler->onAuthenticationSuccess($this->getRequest('/login', 'http://localhost/relayed'), $this->getSamlToken());
+        $this->assertTrue($response->isRedirect($defaultTargetPath), 'SamlAuthenticationSuccessHandler does not honor the always_use_default_target_path option.');
+    }
+
+    public function testRelayState()
+    {
+        $handler = new SamlAuthenticationSuccessHandler(new HttpUtils($this->getUrlGenerator()), array('always_use_default_target_path' => false));
+        $response = $handler->onAuthenticationSuccess($this->getRequest('/sso/login', 'http://localhost/relayed'), $this->getSamlToken());
+        $this->assertTrue($response->isRedirect('http://localhost/relayed'), 'SamlAuthenticationSuccessHandler is not processing the RelayState parameter properly.');
+    }
+
+    public function testWithoutRelayState()
+    {
+        $httpUtils = new HttpUtils($this->getUrlGenerator());
+        $handler = new SamlAuthenticationSuccessHandler($httpUtils, array('always_use_default_target_path' => false));
+        $defaultTargetPath = $httpUtils->generateUri($this->getRequest('/sso/login'), $this->getOption($handler, 'default_target_path', '/'));
+        $response = $handler->onAuthenticationSuccess($this->getRequest(), $this->getSamlToken());
+        $this->assertTrue($response->isRedirect($defaultTargetPath));
+    }
+
+    public function testRelayStateLoop()
+    {
+        $httpUtils = new HttpUtils($this->getUrlGenerator());
+        $handler = new SamlAuthenticationSuccessHandler($httpUtils, array('always_use_default_target_path' => false));
+        $loginPath = $httpUtils->generateUri($this->getRequest('/sso/login'), $this->getOption($handler, 'login_path', '/login'));
+        $response = $handler->onAuthenticationSuccess($this->getRequest($loginPath), $this->getSamlToken());
+        $this->assertTrue(!$response->isRedirect($loginPath), 'SamlAuthenticationSuccessHandler causes a redirect loop when RelayState points to login_path.');
+    }
+
+
+    private function getUrlGenerator()
+    {
+        $urlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $urlGenerator
+            ->expects($this->any())
+            ->method('generate')
+            ->will($this->returnCallback(function($name)
+            {
+                return (string) $name;
+            }))
+        ;
+
+        return $urlGenerator;
+    }
+
+    private function getRequest($path = '/', $relayState = null)
+    {
+        $params = array();
+        if (null !== $relayState) {
+            $params['RelayState'] = $relayState;
+        }
+        return Request::create($path, 'get', $params);
+    }
+
+    private function getSamlToken()
+    {
+        $token = $this->createMock('Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken');
+        $token->expects($this->any())->method('getUsername')->willReturn('admin');
+        $token->method('getAttributes')->willReturn(array('foo' => 'bar'));
+
+        return $token;
+    }
+
+    private function getOption($handler, $name, $default = null)
+    {
+        $reflection = new \ReflectionObject($handler);
+        $options = $reflection->getProperty('options');
+        $options->setAccessible(true);
+        $arr = $options->getValue($handler);
+        if (!is_array($arr) || !isset($arr[$name])) {
+            return $default;
+        }
+        return $arr[$name];
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,4 +22,8 @@
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+    </php>
 </phpunit>


### PR DESCRIPTION
Currently this bundle redirects users to the root of the website after they are successfully authenticated. This PR request changes the default behavior to redirect users to the URL they originally tried to access, which matches the behavior of the default Symfony-provided firewalls.

It is achieved by first modifying the `SamlController` to properly set the `RelayState` parameter to match the URL that the user was denied access to, and then altering the logic responsible for determining the redirect target so that it extracts the URL from the `RelayState`. The target URL is determined in an authentication success handler, so a new `SamlAuthenticationSuccessHandler` to provide the desired behavior has been created.