### PR TITLE
do not attempt to logout if IdP does not support SLO

### DIFF
--- a/Security/Logout/SamlLogoutHandler.php
+++ b/Security/Logout/SamlLogoutHandler.php
@@ -35,8 +35,10 @@ class SamlLogoutHandler implements LogoutHandlerInterface
         try {
             $this->samlAuth->processSLO();
         } catch (\OneLogin\Saml2\Error $e) {
-            $sessionIndex = $token->hasAttribute('sessionIndex') ? $token->getAttribute('sessionIndex') : null;
-            $this->samlAuth->logout(null, array(), $token->getUsername(), $sessionIndex);
+            if (!empty($this->samlAuth->getSLOurl())) {
+                $sessionIndex = $token->hasAttribute('sessionIndex') ? $token->getAttribute('sessionIndex') : null;
+                $this->samlAuth->logout(null, array(), $token->getUsername(), $sessionIndex);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes an exception that is raised if a logout for a SAML token is attempted, whose IdP does not support Single Logout. For example Google apps accounts that utilize this bundle, as Google does not provide SLO functionality. 

Without this code the logout will end in an uncaught exception and user is still logged-in.
With this code the exception is not thrown and the user is logged out due to the regular logout flow in Symfony.

The related code that triggers the exception is 
https://github.com/onelogin/php-saml/blob/c3803254a2ffb36bd0cdbcaf200469309973dd52/lib/Saml2/Auth.php#L549-L555
```php
        $sloUrl = $this->getSLOurl();
        if (empty($sloUrl)) {
            throw new Error(
                'The IdP does not support Single Log Out',
                Error::SAML_SINGLE_LOGOUT_NOT_SUPPORTED
            );
        }
```
FYI @timlegge