### PR TITLE
Apply Symfony Coding Standards and require PHP >= 5.6 explicitly

### DIFF
--- a/Controller/SamlController.php
+++ b/Controller/SamlController.php
@@ -3,9 +3,9 @@
 namespace Hslavich\OneloginSamlBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\HttpFoundation\Request;
 
 class SamlController extends AbstractController
 {

--- a/DependencyInjection/Compiler/SecurityCompilerPass.php
+++ b/DependencyInjection/Compiler/SecurityCompilerPass.php
@@ -2,12 +2,12 @@
 
 namespace Hslavich\OneloginSamlBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Hslavich\OneloginSamlBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 class SecurityCompilerPass implements CompilerPassInterface
 {
@@ -16,14 +16,14 @@ class SecurityCompilerPass implements CompilerPassInterface
         $configs = $container->getExtensionConfig('hslavich_onelogin_saml');
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
-        $emDefinition='doctrine.orm.default_entity_manager';
-        if(!empty($config['security']) && isset($config['security']['entityManagerName'])){
-            $emDefinition='doctrine.orm.'.$config['security']['entityManagerName'].'_entity_manager';
+        $emDefinition = 'doctrine.orm.default_entity_manager';
+        if (!empty($config['security']) && isset($config['security']['entityManagerName'])) {
+            $emDefinition = 'doctrine.orm.'.$config['security']['entityManagerName'].'_entity_manager';
         }
-       
+
         if ($container->hasDefinition($emDefinition)) {
             foreach ($container->findTaggedServiceIds('hslavich.saml_provider') as $id => $tags) {
-                $container->getDefinition($id)->addMethodCall('setEntityManager', array(new Reference($emDefinition)));
+                $container->getDefinition($id)->addMethodCall('setEntityManager', [new Reference($emDefinition)]);
             }
         }
     }
@@ -31,6 +31,7 @@ class SecurityCompilerPass implements CompilerPassInterface
     private function processConfiguration(ConfigurationInterface $configuration, array $configs)
     {
         $processor = new Processor();
+
         return $processor->processConfiguration($configuration, $configs);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,13 +2,13 @@
 
 namespace Hslavich\OneloginSamlBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
 use function is_array;
 use function is_bool;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files
+ * This is the class that validates and merges configuration from your app/config files.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
             $treeBuilder = new TreeBuilder();
             $rootNode = $treeBuilder->root('hslavich_saml_sp');
         }
-        
+
         $rootNode
             ->children()
                 ->scalarNode('baseurl')->end()

--- a/DependencyInjection/HslavichOneloginSamlExtension.php
+++ b/DependencyInjection/HslavichOneloginSamlExtension.php
@@ -2,13 +2,13 @@
 
 namespace Hslavich\OneloginSamlBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */

--- a/DependencyInjection/Security/Factory/SamlFactory.php
+++ b/DependencyInjection/Security/Factory/SamlFactory.php
@@ -3,9 +3,9 @@
 namespace Hslavich\OneloginSamlBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 
 class SamlFactory extends AbstractFactory
@@ -18,7 +18,7 @@ class SamlFactory extends AbstractFactory
         $this->addOption('user_factory');
         $this->addOption('token_factory');
         $this->addOption('persist_user', false);
-        
+
         if (!isset($this->options['success_handler'])) {
             $this->options['success_handler'] = 'hslavich_onelogin_saml.saml_authentication_success_handler';
         }
@@ -50,9 +50,8 @@ class SamlFactory extends AbstractFactory
      * Subclasses must return the id of a service which implements the
      * AuthenticationProviderInterface.
      *
-     * @param ContainerBuilder $container
-     * @param string $id The unique id of the firewall
-     * @param array $config The options array for this listener
+     * @param string $id             The unique id of the firewall
+     * @param array  $config         The options array for this listener
      * @param string $userProviderId The id of the user provider
      *
      * @return string never null, the id of the authentication provider
@@ -63,21 +62,21 @@ class SamlFactory extends AbstractFactory
         $definitionClassname = $this->getDefinitionClassname();
         $definition = $container->setDefinition($providerId, new $definitionClassname('hslavich_onelogin_saml.saml_provider'))
             ->replaceArgument(0, new Reference($userProviderId))
-            ->addArgument(array(
-                 'persist_user' => $config['persist_user']
-            ))
+            ->addArgument([
+                'persist_user' => $config['persist_user'],
+            ])
             ->addTag('hslavich.saml_provider')
         ;
 
         if ($config['user_factory']) {
-            $definition->addMethodCall('setUserFactory', array(new Reference($config['user_factory'])));
+            $definition->addMethodCall('setUserFactory', [new Reference($config['user_factory'])]);
         }
 
         $factoryId = $config['token_factory'] ?: 'hslavich_onelogin_saml.saml_token_factory';
-        $definition->addMethodCall('setTokenFactory', array(new Reference($factoryId)));
+        $definition->addMethodCall('setTokenFactory', [new Reference($factoryId)]);
 
         return $providerId;
-     }
+    }
 
     protected function createListener($container, $id, $config, $userProvider)
     {
@@ -111,7 +110,7 @@ class SamlFactory extends AbstractFactory
             $container
                 ->setDefinition($samlListenerId, new $definitionClassname('saml.security.http.logout'))
                 ->replaceArgument(2, array_intersect_key($config, $this->options));
-            $logoutListener->addMethodCall('addHandler', array(new Reference($samlListenerId)));
+            $logoutListener->addMethodCall('addHandler', [new Reference($samlListenerId)]);
         }
     }
 

--- a/DependencyInjection/Security/Factory/SamlUserProviderFactory.php
+++ b/DependencyInjection/Security/Factory/SamlUserProviderFactory.php
@@ -4,13 +4,13 @@ namespace Hslavich\OneloginSamlBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 
 class SamlUserProviderFactory implements UserProviderFactoryInterface
 {
-    protected $defaultRoles = array('ROLE_USER');
+    protected $defaultRoles = ['ROLE_USER'];
 
     public function create(ContainerBuilder $container, $id, $config)
     {

--- a/Security/Authentication/Provider/SamlProvider.php
+++ b/Security/Authentication/Provider/SamlProvider.php
@@ -2,7 +2,6 @@
 
 namespace Hslavich\OneloginSamlBundle\Security\Authentication\Provider;
 
-use Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken;
 use Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlTokenFactoryInterface;
 use Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlTokenInterface;
 use Hslavich\OneloginSamlBundle\Security\User\SamlUserFactoryInterface;
@@ -21,12 +20,12 @@ class SamlProvider implements AuthenticationProviderInterface
     protected $entityManager;
     protected $options;
 
-    public function __construct(UserProviderInterface $userProvider, array $options = array())
+    public function __construct(UserProviderInterface $userProvider, array $options = [])
     {
         $this->userProvider = $userProvider;
-        $this->options = array_merge(array(
-            'persist_user' => false
-        ), $options);
+        $this->options = array_merge([
+            'persist_user' => false,
+        ], $options);
     }
 
     public function setUserFactory(SamlUserFactoryInterface $userFactory)
@@ -52,7 +51,7 @@ class SamlProvider implements AuthenticationProviderInterface
             if ($user instanceof SamlUserInterface) {
                 $user->setSamlAttributes($token->getAttributes());
             }
-            
+
             $authenticatedToken = $this->tokenFactory->createToken($user, $token->getAttributes(), $user->getRoles());
             $authenticatedToken->setAuthenticated(true);
 
@@ -75,7 +74,7 @@ class SamlProvider implements AuthenticationProviderInterface
             if ($this->userFactory instanceof SamlUserFactoryInterface) {
                 return $this->generateUser($token);
             }
-            
+
             throw $e;
         }
     }

--- a/Security/Authentication/SamlAuthenticationSuccessHandler.php
+++ b/Security/Authentication/SamlAuthenticationSuccessHandler.php
@@ -2,8 +2,8 @@
 
 namespace Hslavich\OneloginSamlBundle\Security\Authentication;
 
-use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 
 class SamlAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
 {

--- a/Security/Authentication/Token/SamlTokenFactory.php
+++ b/Security/Authentication/Token/SamlTokenFactory.php
@@ -5,7 +5,7 @@ namespace Hslavich\OneloginSamlBundle\Security\Authentication\Token;
 class SamlTokenFactory implements SamlTokenFactoryInterface
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function createToken($user, array $attributes, array $roles)
     {

--- a/Security/Authentication/Token/SamlTokenFactoryInterface.php
+++ b/Security/Authentication/Token/SamlTokenFactoryInterface.php
@@ -8,8 +8,6 @@ interface SamlTokenFactoryInterface
      * Creates a new SAML Token object.
      *
      * @param mixed $user
-     * @param array $attributes
-     * @param array $roles
      *
      * @return SamlTokenInterface
      */

--- a/Security/Firewall/SamlListener.php
+++ b/Security/Firewall/SamlListener.php
@@ -16,9 +16,6 @@ class SamlListener extends AbstractAuthenticationListener
      */
     protected $oneLoginAuth;
 
-    /**
-     * @param \OneLogin\Saml2\Auth $oneLoginAuth
-     */
     public function setOneLoginAuth(\OneLogin\Saml2\Auth $oneLoginAuth)
     {
         $this->oneLoginAuth = $oneLoginAuth;
@@ -28,10 +25,11 @@ class SamlListener extends AbstractAuthenticationListener
      * Performs authentication.
      *
      * @param Request $request A Request instance
+     *
      * @return TokenInterface|Response|null The authenticated token, null if full authentication is not possible, or a Response
      *
      * @throws AuthenticationException if the authentication fails
-     * @throws \Exception if attribute set by "username_attribute" option not found
+     * @throws \Exception              if attribute set by "username_attribute" option not found
      */
     protected function attemptAuthentication(Request $request)
     {
@@ -53,7 +51,7 @@ class SamlListener extends AbstractAuthenticationListener
 
         if (isset($this->options['username_attribute'])) {
             if (!array_key_exists($this->options['username_attribute'], $attributes)) {
-                $this->logger->error(sprintf("Found attributes: %s", print_r($attributes, true)));
+                $this->logger->error(sprintf('Found attributes: %s', print_r($attributes, true)));
                 throw new \Exception(sprintf("Attribute '%s' not found in SAML data", $this->options['username_attribute']));
             }
 

--- a/Security/Logout/SamlLogoutHandler.php
+++ b/Security/Logout/SamlLogoutHandler.php
@@ -21,10 +21,6 @@ class SamlLogoutHandler implements LogoutHandlerInterface
      * This method is called by the LogoutListener when a user has requested
      * to be logged out. Usually, you would unset session variables, or remove
      * cookies, etc.
-     *
-     * @param Request $request
-     * @param Response $response
-     * @param TokenInterface $token
      */
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
@@ -37,7 +33,7 @@ class SamlLogoutHandler implements LogoutHandlerInterface
         } catch (\OneLogin\Saml2\Error $e) {
             if (!empty($this->samlAuth->getSLOurl())) {
                 $sessionIndex = $token->hasAttribute('sessionIndex') ? $token->getAttribute('sessionIndex') : null;
-                $this->samlAuth->logout(null, array(), $token->getUsername(), $sessionIndex);
+                $this->samlAuth->logout(null, [], $token->getUsername(), $sessionIndex);
             }
         }
     }

--- a/Security/User/SamlUserFactoryInterface.php
+++ b/Security/User/SamlUserFactoryInterface.php
@@ -11,6 +11,7 @@ interface SamlUserFactoryInterface
      * Creates a new User object from SAML Token.
      *
      * @param SamlTokenInterface $token SAML token
+     *
      * @return UserInterface
      */
     public function createUser(SamlTokenInterface $token);

--- a/Security/User/SamlUserInterface.php
+++ b/Security/User/SamlUserInterface.php
@@ -8,8 +8,6 @@ interface SamlUserInterface extends UserInterface
 {
     /**
      * Set SAML attributes in user object.
-     *
-     * @param array $attributes
      */
     public function setSamlAttributes(array $attributes);
 }

--- a/Security/User/SamlUserProvider.php
+++ b/Security/User/SamlUserProvider.php
@@ -2,8 +2,8 @@
 
 namespace Hslavich\OneloginSamlBundle\Security\User;
 
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class SamlUserProvider implements UserProviderInterface
 {

--- a/Tests/Authentication/Provider/SamlProviderTest.php
+++ b/Tests/Authentication/Provider/SamlProviderTest.php
@@ -12,31 +12,35 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider();
 
-        $this->assertTrue($provider->supports($this->createMock('Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken')));
-        $this->assertFalse($provider->supports($this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')));
+        $this->assertTrue($provider->supports($this->createMock(
+            \Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken::class
+        )));
+        $this->assertFalse($provider->supports($this->createMock(
+            \Symfony\Component\Security\Core\Authentication\Token\TokenInterface::class
+        )));
     }
 
     public function testAuthenticate()
     {
-        $user = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
-        $user->expects($this->once())->method('getRoles')->willReturn(array());
+        $user = $this->createMock(\Symfony\Component\Security\Core\User\UserInterface::class);
+        $user->expects($this->once())->method('getRoles')->willReturn([]);
 
         $provider = $this->getProvider($user);
         $token = $provider->authenticate($this->getSamlToken());
 
-        $this->assertInstanceOf('Hslavich\\OneloginSamlBundle\\Security\\Authentication\\Token\\SamlToken', $token);
-        $this->assertEquals(array('foo' => 'bar'), $token->getAttributes());
+        $this->assertInstanceOf(\Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken::class, $token);
+        $this->assertEquals(['foo' => 'bar'], $token->getAttributes());
         if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID >= 40300) {
-            $this->assertEquals(array(), $token->getRoleNames());
+            $this->assertEquals([], $token->getRoleNames());
         } else {
-            $this->assertEquals(array(), $token->getRoles());
+            $this->assertEquals([], $token->getRoles());
         }
         $this->assertTrue($token->isAuthenticated());
         $this->assertSame($user, $token->getUser());
     }
 
     /**
-     * @expectedException Symfony\Component\Security\Core\Exception\UsernameNotFoundException
+     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
      */
     public function testAuthenticateInvalidUser()
     {
@@ -46,21 +50,21 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testAuthenticateWithUserFactory()
     {
-        $user = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
-        $user->expects($this->once())->method('getRoles')->willReturn(array());
+        $user = $this->createMock(\Symfony\Component\Security\Core\User\UserInterface::class);
+        $user->expects($this->once())->method('getRoles')->willReturn([]);
 
-        $userFactory = $this->createMock('Hslavich\OneloginSamlBundle\Security\User\SamlUserFactoryInterface');
+        $userFactory = $this->createMock(\Hslavich\OneloginSamlBundle\Security\User\SamlUserFactoryInterface::class);
         $userFactory->expects($this->once())->method('createUser')->willReturn($user);
 
         $provider = $this->getProvider(null, $userFactory);
         $token = $provider->authenticate($this->getSamlToken());
 
-        $this->assertInstanceOf('Hslavich\\OneloginSamlBundle\\Security\\Authentication\\Token\\SamlToken', $token);
-        $this->assertEquals(array('foo' => 'bar'), $token->getAttributes());
+        $this->assertInstanceOf(\Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken::class, $token);
+        $this->assertEquals(['foo' => 'bar'], $token->getAttributes());
         if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID >= 40300) {
-            $this->assertEquals(array(), $token->getRoleNames());
+            $this->assertEquals([], $token->getRoleNames());
         } else {
-            $this->assertEquals(array(), $token->getRoles());
+            $this->assertEquals([], $token->getRoles());
         }
         $this->assertTrue($token->isAuthenticated());
         $this->assertSame($user, $token->getUser());
@@ -68,9 +72,9 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testSamlAttributesInjection()
     {
-        $user = $this->createMock('Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface');
-        $user->expects($this->once())->method('getRoles')->willReturn(array());
-        $user->expects($this->once())->method('setSamlAttributes')->with($this->equalTo(array('foo' => 'bar')));
+        $user = $this->createMock(\Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface::class);
+        $user->expects($this->once())->method('getRoles')->willReturn([]);
+        $user->expects($this->once())->method('setSamlAttributes')->with($this->equalTo(['foo' => 'bar']));
 
         $provider = $this->getProvider($user);
         $provider->authenticate($this->getSamlToken());
@@ -78,39 +82,38 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testPersistUser()
     {
-        $user = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
-        $user->expects($this->once())->method('getRoles')->willReturn(array());
+        $user = $this->createMock(\Symfony\Component\Security\Core\User\UserInterface::class);
+        $user->expects($this->once())->method('getRoles')->willReturn([]);
 
-        $userFactory = $this->createMock('Hslavich\OneloginSamlBundle\Security\User\SamlUserFactoryInterface');
+        $userFactory = $this->createMock(\Hslavich\OneloginSamlBundle\Security\User\SamlUserFactoryInterface::class);
         $userFactory->expects($this->once())->method('createUser')->willReturn($user);
 
-        $entityManager = $this->createMock('Doctrine\ORM\EntityManagerInterface', array('persist', 'flush'));
+        $entityManager = $this->createMock(\Doctrine\ORM\EntityManagerInterface::class, ['persist', 'flush']);
         $entityManager->expects($this->once())->method('persist')->with($this->equalTo($user));
 
         $provider = $this->getProvider(null, $userFactory, $entityManager, true);
         $provider->authenticate($this->getSamlToken());
-
     }
 
     protected function getSamlToken()
     {
-        $token = $this->createMock('Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken');
+        $token = $this->createMock(\Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken::class);
         $token->expects($this->once())->method('getUsername')->willReturn('admin');
-        $token->method('getAttributes')->willReturn(array('foo' => 'bar'));
+        $token->method('getAttributes')->willReturn(['foo' => 'bar']);
 
         return $token;
     }
 
     protected function getProvider($user = null, $userFactory = null, $entityManager = null, $persist = false)
     {
-        $userProvider = $this->createMock('Symfony\Component\Security\Core\User\UserProviderInterface');
+        $userProvider = $this->createMock(\Symfony\Component\Security\Core\User\UserProviderInterface::class);
         if ($user) {
             $userProvider->method('loadUserByUsername')->willReturn($user);
         } else {
             $userProvider->method('loadUserByUsername')->will($this->throwException(new UsernameNotFoundException()));
         }
 
-        $provider = new SamlProvider($userProvider, array('persist_user' => $persist));
+        $provider = new SamlProvider($userProvider, ['persist_user' => $persist]);
         $provider->setTokenFactory(new SamlTokenFactory());
 
         if ($userFactory) {

--- a/Tests/Authentication/SamlAuthenticationSuccessHandlerTest.php
+++ b/Tests/Authentication/SamlAuthenticationSuccessHandlerTest.php
@@ -13,7 +13,7 @@ class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
     public function testWithAlwaysUseDefaultTargetPath()
     {
         $httpUtils = new HttpUtils($this->getUrlGenerator());
-        $handler = new SamlAuthenticationSuccessHandler($httpUtils, array('always_use_default_target_path' => true));
+        $handler = new SamlAuthenticationSuccessHandler($httpUtils, ['always_use_default_target_path' => true]);
         $defaultTargetPath = $httpUtils->generateUri($this->getRequest('/sso/login'), $this->getOption($handler, 'default_target_path', '/'));
         $response = $handler->onAuthenticationSuccess($this->getRequest('/login', 'http://localhost/relayed'), $this->getSamlToken());
         $this->assertTrue($response->isRedirect($defaultTargetPath), 'SamlAuthenticationSuccessHandler does not honor the always_use_default_target_path option.');
@@ -21,7 +21,7 @@ class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRelayState()
     {
-        $handler = new SamlAuthenticationSuccessHandler(new HttpUtils($this->getUrlGenerator()), array('always_use_default_target_path' => false));
+        $handler = new SamlAuthenticationSuccessHandler(new HttpUtils($this->getUrlGenerator()), ['always_use_default_target_path' => false]);
         $response = $handler->onAuthenticationSuccess($this->getRequest('/sso/login', 'http://localhost/relayed'), $this->getSamlToken());
         $this->assertTrue($response->isRedirect('http://localhost/relayed'), 'SamlAuthenticationSuccessHandler is not processing the RelayState parameter properly.');
     }
@@ -29,7 +29,7 @@ class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
     public function testWithoutRelayState()
     {
         $httpUtils = new HttpUtils($this->getUrlGenerator());
-        $handler = new SamlAuthenticationSuccessHandler($httpUtils, array('always_use_default_target_path' => false));
+        $handler = new SamlAuthenticationSuccessHandler($httpUtils, ['always_use_default_target_path' => false]);
         $defaultTargetPath = $httpUtils->generateUri($this->getRequest('/sso/login'), $this->getOption($handler, 'default_target_path', '/'));
         $response = $handler->onAuthenticationSuccess($this->getRequest(), $this->getSamlToken());
         $this->assertTrue($response->isRedirect($defaultTargetPath));
@@ -38,21 +38,19 @@ class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
     public function testRelayStateLoop()
     {
         $httpUtils = new HttpUtils($this->getUrlGenerator());
-        $handler = new SamlAuthenticationSuccessHandler($httpUtils, array('always_use_default_target_path' => false));
+        $handler = new SamlAuthenticationSuccessHandler($httpUtils, ['always_use_default_target_path' => false]);
         $loginPath = $httpUtils->generateUri($this->getRequest('/sso/login'), $this->getOption($handler, 'login_path', '/login'));
         $response = $handler->onAuthenticationSuccess($this->getRequest($loginPath), $this->getSamlToken());
         $this->assertTrue(!$response->isRedirect($loginPath), 'SamlAuthenticationSuccessHandler causes a redirect loop when RelayState points to login_path.');
     }
 
-
     private function getUrlGenerator()
     {
-        $urlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $urlGenerator = $this->getMockBuilder(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class)->getMock();
         $urlGenerator
             ->expects($this->any())
             ->method('generate')
-            ->will($this->returnCallback(function($name)
-            {
+            ->will($this->returnCallback(function ($name) {
                 return (string) $name;
             }))
         ;
@@ -62,18 +60,19 @@ class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
 
     private function getRequest($path = '/', $relayState = null)
     {
-        $params = array();
+        $params = [];
         if (null !== $relayState) {
             $params['RelayState'] = $relayState;
         }
+
         return Request::create($path, 'get', $params);
     }
 
     private function getSamlToken()
     {
-        $token = $this->createMock('Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken');
+        $token = $this->createMock(\Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken::class);
         $token->expects($this->any())->method('getUsername')->willReturn('admin');
-        $token->method('getAttributes')->willReturn(array('foo' => 'bar'));
+        $token->method('getAttributes')->willReturn(['foo' => 'bar']);
 
         return $token;
     }
@@ -87,6 +86,7 @@ class SamlAuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
         if (!is_array($arr) || !isset($arr[$name])) {
             return $default;
         }
+
         return $arr[$name];
     }
 }

--- a/Tests/DependencyInjection/HslavichOneloginSamlExtensionTest.php
+++ b/Tests/DependencyInjection/HslavichOneloginSamlExtensionTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class HslavichOneloginSamlExtensionTest extends \PHPUnit_Framework_TestCase
 {
-    private static $containerCache = array();
+    private static $containerCache = [];
 
     public function testLoadIdpSettings()
     {
@@ -25,8 +25,8 @@ class HslavichOneloginSamlExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('idp_x509certdata', $settings['idp']['x509cert']);
         $this->assertEquals('43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8', $settings['idp']['certFingerprint']);
         $this->assertEquals('sha1', $settings['idp']['certFingerprintAlgorithm']);
-        $this->assertEquals(array('<cert1-string>'), $settings['idp']['x509certMulti']['signing']);
-        $this->assertEquals(array('<cert2-string>'), $settings['idp']['x509certMulti']['encryption']);
+        $this->assertEquals(['<cert1-string>'], $settings['idp']['x509certMulti']['signing']);
+        $this->assertEquals(['<cert2-string>'], $settings['idp']['x509certMulti']['encryption']);
     }
 
     public function testLoadSpSettings()
@@ -97,9 +97,9 @@ class HslavichOneloginSamlExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function createContainer()
     {
-        return new ContainerBuilder(new ParameterBag(array(
-            'kernel.bundles' => array('FrameworkBundle' => HslavichOneloginSamlBundle::class),
-            'kernel.bundles_metadata' => array('HslavichOneloginSamlBundle' => array('namespace' => 'Hslavich\\OneloginSamlBundle\\HslavichOneloginSamlBundle', 'path' => __DIR__.'/../..')),
+        return new ContainerBuilder(new ParameterBag([
+            'kernel.bundles' => ['FrameworkBundle' => HslavichOneloginSamlBundle::class],
+            'kernel.bundles_metadata' => ['HslavichOneloginSamlBundle' => ['namespace' => 'Hslavich\\OneloginSamlBundle\\HslavichOneloginSamlBundle', 'path' => __DIR__.'/../..']],
             'kernel.cache_dir' => __DIR__,
             'kernel.project_dir' => __DIR__,
             'kernel.debug' => false,
@@ -110,7 +110,7 @@ class HslavichOneloginSamlExtensionTest extends \PHPUnit_Framework_TestCase
             'container.build_hash' => 'Abc1234',
             'container.build_id' => hash('crc32', 'Abc123423456789'),
             'container.build_time' => 23456789,
-        )));
+        ]));
     }
 
     protected function createContainerFromFile($file)
@@ -123,8 +123,8 @@ class HslavichOneloginSamlExtensionTest extends \PHPUnit_Framework_TestCase
         $container->registerExtension(new HslavichOneloginSamlExtension());
         $this->loadFromFile($container, $file);
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
 
         $container->compile();
 

--- a/Tests/DependencyInjection/Security/Factory/SamlFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/SamlFactoryTest.php
@@ -2,11 +2,10 @@
 
 namespace Hslavich\OneloginSamlBundle\Tests\DependencyInjection\Security\Provider;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\DependencyInjection\Reference;
 use Hslavich\OneloginSamlBundle\DependencyInjection\Security\Factory\SamlFactory;
-use Hslavich\OneloginSamlBundle\Tests\TestUser;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 class SamlFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,51 +14,51 @@ class SamlFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddConfig(array $inputConfig, array $expectedConfig)
     {
-      $factory = new SamlFactory();
-      $nodeDefinition = new ArrayNodeDefinition($factory->getKey());
-      $factory->addConfiguration($nodeDefinition);
+        $factory = new SamlFactory();
+        $nodeDefinition = new ArrayNodeDefinition($factory->getKey());
+        $factory->addConfiguration($nodeDefinition);
 
-      $node = $nodeDefinition->getNode();
-      $normalizedConfig = $node->normalize($inputConfig);
-      $finalizedConfig = $node->finalize($normalizedConfig);
+        $node = $nodeDefinition->getNode();
+        $normalizedConfig = $node->normalize($inputConfig);
+        $finalizedConfig = $node->finalize($normalizedConfig);
 
-      $this->assertArraySubset($expectedConfig, $finalizedConfig);
+        $this->assertArraySubset($expectedConfig, $finalizedConfig);
     }
 
     public function getConfigurationTests()
     {
-        $tests = array();
+        $tests = [];
 
-        $tests[] = array(
-            array(
+        $tests[] = [
+            [
                 'username_attribute' => 'uid',
                 'login_path' => '/my_login',
                 'check_path' => '/my_login_check',
                 'user_factory' => 'my_user_factory',
                 'token_factory' => 'my_token_factory',
                 'persist_user' => true,
-            ),
-            array(
+            ],
+            [
                 'username_attribute' => 'uid',
                 'login_path' => '/my_login',
                 'check_path' => '/my_login_check',
                 'user_factory' => 'my_user_factory',
                 'token_factory' => 'my_token_factory',
                 'persist_user' => true,
-            )
-        );
+            ],
+        ];
 
-        $tests[] = array(
-            array(),
-            array(
+        $tests[] = [
+            [],
+            [
                 'username_attribute' => null,
                 'login_path' => '/saml/login',
                 'check_path' => '/saml/acs',
                 'user_factory' => null,
                 'token_factory' => null,
                 'persist_user' => false,
-            )
-        );
+            ],
+        ];
 
         return $tests;
     }
@@ -71,11 +70,11 @@ class SamlFactoryTest extends \PHPUnit_Framework_TestCase
         $nodeDefinition = new ArrayNodeDefinition($factory->getKey());
         $factory->addConfiguration($nodeDefinition);
 
-        $config = array(
+        $config = [
             'username_attribute' => null,
             'login_path' => '/saml/login',
             'check_path' => '/saml/acs',
-        );
+        ];
         $node = $nodeDefinition->getNode();
         $normalizedConfig = $node->normalize($config);
         $finalizedConfig = $node->finalize($normalizedConfig);
@@ -83,9 +82,9 @@ class SamlFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->create($container, 'test_firewall', $finalizedConfig, 'my_user_provider', null);
 
         $providerDefinition = $container->getDefinition('security.authentication.provider.saml.test_firewall');
-        $this->assertEquals(array(
+        $this->assertEquals([
             'index_0' => new Reference('my_user_provider'),
-            0 => array('persist_user' => false)
-        ), $providerDefinition->getArguments());
+            0 => ['persist_user' => false],
+        ], $providerDefinition->getArguments());
     }
 }

--- a/Tests/DependencyInjection/Security/Factory/SamlUserProviderFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/SamlUserProviderFactoryTest.php
@@ -2,10 +2,10 @@
 
 namespace Hslavich\OneloginSamlBundle\Tests\DependencyInjection\Security\Provider;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Hslavich\OneloginSamlBundle\DependencyInjection\Security\Factory\SamlUserProviderFactory;
 use Hslavich\OneloginSamlBundle\Tests\TestUser;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SamlUserProviderFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,10 +15,10 @@ class SamlUserProviderFactoryTest extends \PHPUnit_Framework_TestCase
         $nodeDefinition = new ArrayNodeDefinition('saml');
         $factory->addConfiguration($nodeDefinition);
 
-        $config = array(
+        $config = [
             'user_class' => TestUser::class,
-            'default_roles' => array('ROLE_ADMIN')
-        );
+            'default_roles' => ['ROLE_ADMIN'],
+        ];
 
         $node = $nodeDefinition->getNode();
         $normalizedConfig = $node->normalize($config);
@@ -36,7 +36,7 @@ class SamlUserProviderFactoryTest extends \PHPUnit_Framework_TestCase
         $nodeDefinition = new ArrayNodeDefinition('saml');
         $factory->addConfiguration($nodeDefinition);
 
-        $config = array('default_roles' => array('ROLE_ADMIN'));
+        $config = ['default_roles' => ['ROLE_ADMIN']];
 
         $node = $nodeDefinition->getNode();
         $normalizedConfig = $node->normalize($config);
@@ -48,15 +48,15 @@ class SamlUserProviderFactoryTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $factory = new SamlUserProviderFactory();
 
-        $config = array(
+        $config = [
             'user_class' => TestUser::class,
-            'default_roles' => array('ROLE_USER')
-        );
+            'default_roles' => ['ROLE_USER'],
+        ];
 
         $factory->create($container, 'test_provider', $config);
 
         $providerDefinition = $container->getDefinition('test_provider');
         $this->assertEquals(TestUser::class, $providerDefinition->getArgument(0));
-        $this->assertEquals(array('ROLE_USER'), $providerDefinition->getArgument(1));
+        $this->assertEquals(['ROLE_USER'], $providerDefinition->getArgument(1));
     }
 }

--- a/Tests/Firewall/SamlListenerTest.php
+++ b/Tests/Firewall/SamlListenerTest.php
@@ -3,7 +3,6 @@
 namespace Hslavich\OneloginSamlBundle\Tests\Firewall;
 
 use Hslavich\OneloginSamlBundle\Security\Firewall\SamlListener;
-use Symfony\Component\HttpFoundation\Request;
 
 class SamlProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -17,11 +16,11 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleValidAuthenticationWithAttribute()
     {
-        $listener = $this->getListener(array('username_attribute' => 'uid'));
+        $listener = $this->getListener(['username_attribute' => 'uid']);
 
-        $attributes = array('uid' => array('username_uid'));
+        $attributes = ['uid' => ['username_uid']];
 
-        $onelogin = $this->getMockBuilder('OneLogin\Saml2\Auth')->disableOriginalConstructor()->getMock();
+        $onelogin = $this->getMockBuilder(\OneLogin\Saml2\Auth::class)->disableOriginalConstructor()->getMock();
         $onelogin->expects($this->once())->method('processResponse');
         $onelogin
             ->expects($this->once())
@@ -39,14 +38,14 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleValidAuthenticationWithEmptyOptions()
     {
-        $listener = $this->getListener(array());
+        $listener = $this->getListener([]);
 
-        $onelogin = $this->getMockBuilder('OneLogin\Saml2\Auth')->disableOriginalConstructor()->getMock();
+        $onelogin = $this->getMockBuilder(\OneLogin\Saml2\Auth::class)->disableOriginalConstructor()->getMock();
         $onelogin->expects($this->once())->method('processResponse');
         $onelogin
             ->expects($this->once())
             ->method('getAttributes')
-            ->will($this->returnValue(array()))
+            ->will($this->returnValue([]))
         ;
         $onelogin
             ->expects($this->once())
@@ -62,7 +61,7 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    protected function getListener($options = array())
+    protected function getListener($options = [])
     {
         return new SamlListener(
             $this->tokenStorage,
@@ -70,21 +69,23 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
             $this->sessionStrategy,
             $this->httpUtils,
             'secured_area',
-            $this->createMock('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface'),
-            $this->createMock('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface'),
+            $this->createMock(\Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface::class),
+            $this->createMock(\Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface::class),
             $options
         );
     }
 
     protected function setUp()
     {
-        $this->httpKernel = $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface');
-        $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')
+        $this->httpKernel = $this->createMock(\Symfony\Component\HttpKernel\HttpKernelInterface::class);
+        $this->authenticationManager = $this->getMockBuilder(
+            \Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager::class
+        )
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $this->dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $this->dispatcher = $this->createMock(\Symfony\Component\EventDispatcher\EventDispatcherInterface::class);
+        $this->request = $this->createMock(\Symfony\Component\HttpFoundation\Request::class);
         $this->request
             ->expects($this->any())
             ->method('hasSession')
@@ -97,9 +98,9 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
         ;
 
         if (class_exists('Symfony\Component\HttpKernel\Event\RequestEvent')) {
-            $this->event = $this->createMock('Symfony\Component\HttpKernel\Event\RequestEvent', array(), array(), '', false);
+            $this->event = $this->createMock(\Symfony\Component\HttpKernel\Event\RequestEvent::class, [], [], '', false);
         } else {
-            $this->event = $this->createMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false);
+            $this->event = $this->createMock(\Symfony\Component\HttpKernel\Event\GetResponseEvent::class, [], [], '', false);
         }
         $this->event
             ->expects($this->any())
@@ -111,15 +112,17 @@ class SamlProviderTest extends \PHPUnit_Framework_TestCase
             ->method('getKernel')
             ->will($this->returnValue($this->httpKernel))
         ;
-        $this->sessionStrategy = $this->createMock('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface');
-        $this->httpUtils = $this->createMock('Symfony\Component\Security\Http\HttpUtils');
+        $this->sessionStrategy = $this->createMock(
+            \Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface::class
+        );
+        $this->httpUtils = $this->createMock(\Symfony\Component\Security\Http\HttpUtils::class);
         $this->httpUtils
             ->expects($this->any())
             ->method('checkRequestPath')
             ->will($this->returnValue(true))
         ;
 
-        $reflection = new \ReflectionClass('Hslavich\OneloginSamlBundle\Security\Firewall\SamlListener');
+        $reflection = new \ReflectionClass(SamlListener::class);
         $params = $reflection->getConstructor()->getParameters();
         $param = $params[0];
         $this->tokenStorage = $this->createMock($param->getClass()->name);

--- a/Tests/TestUser.php
+++ b/Tests/TestUser.php
@@ -13,7 +13,7 @@ class TestUser implements UserInterface
     private $lastname;
     private $roles;
 
-    public function __construct($username = '', $roles = array())
+    public function __construct($username = '', $roles = [])
     {
         $this->username = $username;
         $this->roles = $roles;

--- a/Tests/User/SamlUserFactoryTest.php
+++ b/Tests/User/SamlUserFactoryTest.php
@@ -2,29 +2,29 @@
 
 namespace Hslavich\OneloginSamlBundle\Tests\User;
 
+use Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken;
 use Hslavich\OneloginSamlBundle\Security\User\SamlUserFactory;
 use Hslavich\OneloginSamlBundle\Tests\TestUser;
-use Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlToken;
 
 class SamlUserFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testUserMapping()
     {
-        $map = array(
+        $map = [
             'password' => 'notused',
             'email' => '$mail',
             'name' => '$cn',
             'lastname' => '$sn',
-            'roles' => ['ROLE_USER']
-        );
+            'roles' => ['ROLE_USER'],
+        ];
 
         $token = $this->createMock(SamlToken::class);
         $token->method('getUsername')->willReturn('admin');
-        $token->method('getAttributes')->willReturn(array(
-            'mail' => array('email@mail.com'),
-            'cn' => array('testname'),
-            'sn' => array('testlastname')
-        ));
+        $token->method('getAttributes')->willReturn([
+            'mail' => ['email@mail.com'],
+            'cn' => ['testname'],
+            'sn' => ['testlastname'],
+        ]);
 
         $factory = new SamlUserFactory(TestUser::class, $map);
         $user = $factory->createUser($token);
@@ -36,5 +36,4 @@ class SamlUserFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('notused', $user->getPassword());
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
     }
-
 }

--- a/Tests/User/SamlUserProviderTest.php
+++ b/Tests/User/SamlUserProviderTest.php
@@ -8,16 +8,16 @@ class SamlUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testLoadByUsername()
     {
-        $provider = $this->getUserProvider(array('ROLE_ADMIN'));
+        $provider = $this->getUserProvider(['ROLE_ADMIN']);
         $user = $provider->loadUserByUsername('admin');
 
         $this->assertEquals('admin', $user->getUsername());
-        $this->assertEquals(array('ROLE_ADMIN'), $user->getRoles());
+        $this->assertEquals(['ROLE_ADMIN'], $user->getRoles());
     }
 
     public function testRefreshUser()
     {
-        $user = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->createMock(\Symfony\Component\Security\Core\User\UserInterface::class);
         $provider = $this->getUserProvider();
 
         $this->assertSame($user, $provider->refreshUser($user));
@@ -27,12 +27,12 @@ class SamlUserProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getUserProvider();
 
-        $this->assertTrue($provider->supportsClass('Hslavich\OneloginSamlBundle\Tests\TestUser'));
-        $this->assertFalse($provider->supportsClass('Symfony\Component\Security\Core\User\UserInterface'));
+        $this->assertTrue($provider->supportsClass(\Hslavich\OneloginSamlBundle\Tests\TestUser::class));
+        $this->assertFalse($provider->supportsClass(\Symfony\Component\Security\Core\User\UserInterface::class));
     }
 
-    protected function getUserProvider($roles = array())
+    protected function getUserProvider($roles = [])
     {
-        return new SamlUserProvider('Hslavich\OneloginSamlBundle\Tests\TestUser', $roles);
+        return new SamlUserProvider(\Hslavich\OneloginSamlBundle\Tests\TestUser::class, $roles);
     }
 }


### PR DESCRIPTION
- Require PHP >=5.6 (already implicitly done with the use of imported functions in some files)  explicitly in `composer.json` file.
- Apply [Symfony Coding Standards](https://symfony.com/doc/current/contributing/code/standards.html)

This PR includes not BC with regards to the previous version.
All tests are greens !