### PR TITLE
Added missing responseUrl config option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('singleLogoutService')
                             ->children()
                                 ->scalarNode('url')->end()
+                                ->scalarNode('responseUrl')->end()
                                 ->scalarNode('binding')->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
php-saml allows you to set `responseUrl` which is the location of the IdP where the SP will send the SLO Response to.