### PR TITLE
added "allowRepeatAttributeName" to security settings

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -118,6 +118,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('signMetadata')->end()
                         ->booleanNode('wantXMLValidation')->end()
                         ->booleanNode('relaxDestinationValidation')->end()
+                        ->booleanNode('allowRepeatAttributeName')->end()
                         ->booleanNode('destinationStrictlyMatches')
                             ->defaultTrue()
                         ->end()


### PR DESCRIPTION
I've added the config value "allowRepeatAttributeName" to the TreeBuilder of the configuration, which is a configuration parameter introduced in commit 370a5d9 of the php-saml libary.
https://github.com/onelogin/php-saml/commit/370a5d9c8432ede5776f278edcdcf3b8e8212cc6