### PR TITLE
Symfony 5.3 support : fix deprecated usage of UserInterface for SelfValidatingPassport

### DIFF
--- a/Security/Http/Authenticator/Passport/SamlPassport.php
+++ b/Security/Http/Authenticator/Passport/SamlPassport.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Hslavich\OneloginSamlBundle\Security\Http\Authenticator\Passport;
 
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
 class SamlPassport extends SelfValidatingPassport implements SamlPassportInterface
 {
     private $attributes;
 
-    public function __construct(UserInterface $user, array $attributes, array $badges = [])
+    public function __construct(UserBadge $userBadge, array $attributes, array $badges = [])
     {
-        parent::__construct($user, $badges);
+        parent::__construct($userBadge, $badges);
 
         $this->attributes = $attributes;
     }


### PR DESCRIPTION
Security component in symfony 5.3 introduced a breaking change, removing the deprecated support for passing a `UserInterface` to Passport instead of a `UserBadge`.

* Update `SamlPassport` to expect a `UserBadge` like `SelfValidatingPassport` 
* Update `SamlAuthenticator` to give a `UserBadge` instead of a `UserInterface` to the passport, moving all fetch and user factory generation inside the loader of `UserBadge`

Tests are failing on master but this commit doesn't seems to introduce new errors on top of the already failing cases so it should be OK (*but I am not familiar with this code base nor the new symfony authentication API*)