### PR TITLE
Update SamlProvider.php

### DIFF
--- a/Security/Authentication/Provider/SamlProvider.php
+++ b/Security/Authentication/Provider/SamlProvider.php
@@ -53,8 +53,10 @@ class SamlProvider implements AuthenticationProviderInterface
         if ($user) {
             if ($user instanceof SamlUserInterface) {
                 $user->setSamlAttributes($token->getAttributes());
-                $this->entityManager->persist($user);
-                $this->entityManager->flush();
+                if ($this->entityManager) {
+                    $this->entityManager->persist($user);
+                    $this->entityManager->flush();
+                }
             }
 
             $authenticatedToken = $this->tokenFactory->createToken($user, $token->getAttributes(), $user->getRoles());

--- a/Security/Authentication/Provider/SamlProvider.php
+++ b/Security/Authentication/Provider/SamlProvider.php
@@ -53,6 +53,8 @@ class SamlProvider implements AuthenticationProviderInterface
         if ($user) {
             if ($user instanceof SamlUserInterface) {
                 $user->setSamlAttributes($token->getAttributes());
+                $this->entityManager->persist($user);
+                $this->entityManager->flush();
             }
 
             $authenticatedToken = $this->tokenFactory->createToken($user, $token->getAttributes(), $user->getRoles());

--- a/Security/Http/Authenticator/SamlAuthenticator.php
+++ b/Security/Http/Authenticator/SamlAuthenticator.php
@@ -142,7 +142,7 @@ class SamlAuthenticator implements AuthenticatorInterface, AuthenticationEntryPo
                         $this->entityManager->persist($user);
                         $this->entityManager->flush();
                     }
-               }
+                }
 
                 return $user;
             }

--- a/Security/Http/Authenticator/SamlAuthenticator.php
+++ b/Security/Http/Authenticator/SamlAuthenticator.php
@@ -138,7 +138,11 @@ class SamlAuthenticator implements AuthenticatorInterface, AuthenticationEntryPo
 
                 if ($user instanceof SamlUserInterface) {
                     $user->setSamlAttributes($attributes);
-                }
+                    if ($this->entityManager) {
+                        $this->entityManager->persist($user);
+                        $this->entityManager->flush();
+                    }
+               }
 
                 return $user;
             }


### PR DESCRIPTION
Fixes hslavich#155
Fixes hslavich#148

If I update roles with setSamlAttributes it works well, the tokenFactory genereates the right token. But at the next page refresh it redirects back to login page. It's because of this:
[2021-06-03T11:37:01.687883+02:00] security.DEBUG: Cannot refresh token because user has changed. {"username":"test","provider":"Symfony\Bridge\Doctrine\Security\User\EntityUserProvider"} []
[2021-06-03T11:37:01.688630+02:00] security.DEBUG: Token was deauthenticated after trying to refresh it. [] []
The token's roles and the saved User Entity's roles mismatching. But with this PR the User Entity is peristed after calling setSamlAttributes(), so at the next tokenrefresh it matches the previosly generated token.