### PR TITLE
Remove the private $attributes property

### DIFF
--- a/Security/Http/Authenticator/Passport/SamlPassport.php
+++ b/Security/Http/Authenticator/Passport/SamlPassport.php
@@ -9,17 +9,12 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 
 class SamlPassport extends SelfValidatingPassport implements SamlPassportInterface
 {
-    private $attributes;
-
     public function __construct(UserBadge $userBadge, array $attributes, array $badges = [])
     {
         parent::__construct($userBadge, $badges);
 
-        $this->attributes = $attributes;
-    }
-
-    public function getAttributes(): array
-    {
-        return $this->attributes;
+        foreach($attributes as $name => $value) {
+            $this->setAttribute($name, $value);
+        }
     }
 }

--- a/Security/Http/Authenticator/Passport/SamlPassportInterface.php
+++ b/Security/Http/Authenticator/Passport/SamlPassportInterface.php
@@ -8,5 +8,5 @@ use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface
 
 interface SamlPassportInterface extends UserPassportInterface
 {
-    public function getAttributes(): array;
+
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/deprecation-contracts": "^2.1",
         "symfony/event-dispatcher-contracts": "^2.4",
         "symfony/framework-bundle": "^5.3",
-        "symfony/security-bundle": "^5.3"
+        "symfony/security-bundle": "^5.4"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.2.0",


### PR DESCRIPTION
Fixes #181. Remove the private $attributes property as it exists in the Passport and a getAttributes() function has just been merged into the Symfony 5.4 branch