### PR TITLE
Bump symfony/deprecation-contracts to allow ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "onelogin/php-saml": "^3.0",
         "symfony/dependency-injection": "^5.4",
-        "symfony/deprecation-contracts": "^2.1",
+        "symfony/deprecation-contracts": "^2.1 | ^3",
         "symfony/event-dispatcher-contracts": "^2.4",
         "symfony/framework-bundle": "^5.4",
         "symfony/security-bundle": "^5.4"


### PR DESCRIPTION
Only difference between deprecation-contracts 2.5.x and 3.x is adding the `mixed` parameter type in [c726b64](https://github.com/symfony/deprecation-contracts/commit/c726b64c1ccfe2896cb7df2e1331c357ad1c8ced)

This should be a safe change since we still allow ^2.1. which still supports php 7

Resolves #197 