### PR TITLE
The saml authenticator is an interactive authenticator

### DIFF
--- a/Security/Http/Authenticator/SamlAuthenticator.php
+++ b/Security/Http/Authenticator/SamlAuthenticator.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
@@ -32,7 +32,7 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class SamlAuthenticator implements AuthenticatorInterface, AuthenticationEntryPointInterface
+class SamlAuthenticator implements InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {
     private $httpUtils;
     private $userProvider;
@@ -129,6 +129,11 @@ class SamlAuthenticator implements AuthenticatorInterface, AuthenticationEntryPo
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
         return $this->failureHandler->onAuthenticationFailure($request, $exception);
+    }
+
+    public function isInteractive(): bool
+    {
+        return true;
     }
 
     protected function createPassport(): Passport


### PR DESCRIPTION
https://github.com/symfony/symfony/pull/33558 has added a differentiation between interactive and not interactive authenticators.

when this bundle was compatible with older symfony versions, was dispatching the interactive login event, while now it stopped ding so. 

I have implemented then new `InteractiveAuthenticatorInterface` to allow symfony to dispatch the event.