### PR TITLE
Added user_checker support

### DIFF
--- a/DependencyInjection/Security/Factory/SamlFactory.php
+++ b/DependencyInjection/Security/Factory/SamlFactory.php
@@ -91,6 +91,7 @@ class SamlFactory extends AbstractFactory
         $definition = $container->setDefinition($providerId, new $definitionClassname('hslavich_onelogin_saml.saml_provider'))
             ->replaceArgument(0, new Reference($userProviderId))
             ->replaceArgument(1, new Reference('event_dispatcher', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->replaceArgument(2, new Reference('security.user_checker.'.$id))
         ;
 
         if ($config['user_factory']) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,7 +15,7 @@ services:
 
     hslavich_onelogin_saml.saml_provider:
         class: Hslavich\OneloginSamlBundle\Security\Authentication\Provider\SamlProvider
-        arguments: ["", ""]
+        arguments: ["", "", ""]
 
     hslavich_onelogin_saml.saml_token_factory:
         class: Hslavich\OneloginSamlBundle\Security\Authentication\Token\SamlTokenFactory

--- a/Tests/DependencyInjection/Security/Factory/SamlFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/SamlFactoryTest.php
@@ -86,7 +86,8 @@ class SamlFactoryTest extends \PHPUnit_Framework_TestCase
         $providerDefinition = $container->getDefinition('security.authentication.provider.saml.test_firewall');
         $this->assertEquals(array(
             'index_0' => new Reference('my_user_provider'),
-            'index_1' => new Reference('event_dispatcher', ContainerInterface::NULL_ON_INVALID_REFERENCE)
+            'index_1' => new Reference('event_dispatcher', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            'index_2' => new Reference('security.user_checker.test_firewall')
         ), $providerDefinition->getArguments());
     }
 }


### PR DESCRIPTION
user_checkers in Symfony allow to verify if the identified user is allowed to log in :
https://symfony.com/doc/current/security/user_checkers.html

This PR permits using user_checkers if configured.
